### PR TITLE
update bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "license": "Apache 2.0",
   "dependencies": {
-    "bluebird": "~2.2.2",
+    "bluebird": "~2.8.2",
     "forever-agent": "~0.5.2",
     "lodash-node": "~2.4"
   },


### PR DESCRIPTION
i've updated the bluebird dependency.

i've got an app which uses elasticsearch and i'm having issues with memory in my app (not in elasticsearch server).  heapdumps show some bluebird promises hanging around but i'm not convinced there is reason to be concerned about those specifically but given that bluebird has moved forward quite a bit from the version you were using, i figured it wouldn't hurt to update the dependency.

refs #159