### PR TITLE
Add 504 error handling and update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Please write test cases to exercise your changes.
   Or to skip the integration tests:
 
   ```sh
-  grunt test_unit
+  grunt unit_test
   ```
 4. Optionally, run the browser tests. While this step is automated and simple, it can take several minutes for the tests to complete. Unless you are making changes to browser specific portions of the code you can probably let Travis run the browser tests for you.
 

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -80,6 +80,12 @@ _.inherits(errors.RequestTypeError, ErrorAbstract);
 var statusCodes = {
 
   /**
+   * GatewayTimeout
+   * @param {String} [msg] - An error message that will probably end up in a log.
+   */
+  504: 'Gateway Timeout',
+
+  /**
    * ServiceUnavailable
    * @param {String} [msg] - An error message that will probably end up in a log.
    */


### PR DESCRIPTION
The 504 (Gateway Timeout) response was not being handled by the client. This adds it to the list of HTTP codes to handle.

In addition, it updates the contributing guide to fix a mistake where it listed the unit testing command as `grunt test_unit` instead of `grunt unit_test`.