### PR TITLE
Update browser_builds.asciidoc

### DIFF
--- a/docs/browser_builds.asciidoc
+++ b/docs/browser_builds.asciidoc
@@ -14,7 +14,7 @@ bower install elasticsearch
 ---------
 
 === Download
- * v3.1.3: https://download.elasticsearch.org/elasticsearch/elasticsearch-js/elasticsearch-js-3.1.3.zip[zip], https://download.elasticsearch.org/elasticsearch/elasticsearch-js/elasticsearch-js-3.1.3.tar.gz[tar.gz]
+ * v3.1.1: https://download.elasticsearch.org/elasticsearch/elasticsearch-js/elasticsearch-js-3.1.1.zip[zip], https://download.elasticsearch.org/elasticsearch/elasticsearch-js/elasticsearch-js-3.1.1.tar.gz[tar.gz]
 
 
 === Angular Build


### PR DESCRIPTION
The download link 'v3.1.1' doesn't work. The reported error is reports an error:

<Error>
<Code>NoSuchKey</Code>
<Message>The specified key does not exist.</Message>
<Key>
elasticsearch/elasticsearch-js/elasticsearch-js-3.1.3.zip
</Key>
<RequestId>EF416DAD8A321ED3</RequestId>
<HostId>
DJYUpZ2uiecv+DvFrnUkObW/y0AHi3klFjrvCr7yKjOT3YeYkloofy2R1FDv3IcMMg3DjnEaXgk=
</HostId>
</Error>

I've changed it to the last documented release as per the github page (https://github.com/elasticsearch/elasticsearch-js/releases)  which also has a valid download link.

Dan